### PR TITLE
Fix CLI price history symbol handling and bump version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schwab_rb (0.6.1)
+    schwab_rb (0.7.1)
       async (~> 2.18)
       async-http (~> 0.82)
       dotenv

--- a/lib/schwab_rb/cli/app.rb
+++ b/lib/schwab_rb/cli/app.rb
@@ -16,6 +16,9 @@ module SchwabRb
     # rubocop:disable Metrics/ClassLength
     class App
       DEFAULT_DATA_DIR = "~/.schwab_rb/data"
+      INDEX_API_SYMBOLS = %w[
+        COMPX DJX MID NDX OEX RUT SPX VIX VIX9D VIX1D XSP
+      ].freeze
       SUPPORTED_FORMATS = %w[csv json].freeze
       PERIOD_TYPES = {
         "day" => SchwabRb::PriceHistory::PeriodTypes::DAY,
@@ -206,6 +209,7 @@ module SchwabRb
         parser.parse!(argv)
         raise Error, "Unexpected arguments: #{argv.join(' ')}" if argv.any?
 
+        options[:end_date] = normalized_end_date(options.fetch(:end_date))
         validate_price_history_options!(options)
 
         _, output_path = resolve_price_history_response(options)
@@ -223,12 +227,21 @@ module SchwabRb
         existing_response = load_cached_price_history(directory, options)
         response = existing_response
 
-        unless cached_range_covers?(existing_response, options.fetch(:start_date), options.fetch(:end_date))
+        unless cached_range_covers?(
+          existing_response,
+          options.fetch(:start_date),
+          options.fetch(:end_date),
+          options.fetch(:freq)
+        )
           client = build_non_interactive_client
-          missing_ranges(existing_response, options.fetch(:start_date), options.fetch(:end_date)).each do |range|
-            downloaded = fetch_price_history_range(client, options, range.fetch(:start_date), range.fetch(:end_date))
-            response = merge_price_history_responses(response, downloaded, options.fetch(:symbol))
-          end
+          downloaded = fetch_price_history_range(
+            client,
+            options,
+            options.fetch(:start_date),
+            options.fetch(:end_date)
+          )
+
+          response = merge_price_history_responses(response, downloaded, options.fetch(:symbol))
         end
 
         output_path = canonical_output_path(directory, options)
@@ -236,24 +249,6 @@ module SchwabRb
         [response, output_path]
       end
       # rubocop:enable Metrics/AbcSize
-
-      def write_price_history(response, options)
-        directory = SchwabRb::PathSupport.expand_path(options.fetch(:dir))
-        FileUtils.mkdir_p(directory)
-
-        filename = build_filename(
-          options.fetch(:symbol),
-          options.fetch(:freq),
-          options.fetch(:start_date),
-          options.fetch(:end_date),
-          options.fetch(:format)
-        )
-        output_path = File.join(directory, filename)
-        payload = serialized_payload(response, options.fetch(:format))
-
-        File.write(output_path, payload)
-        output_path
-      end
 
       def write_payload(output_path, response, format)
         File.write(output_path, serialized_payload(response, format))
@@ -335,25 +330,15 @@ module SchwabRb
         }
       end
 
-      def cached_range_covers?(response, start_date, end_date)
+      def cached_range_covers?(response, start_date, end_date, frequency)
         return false unless response
 
-        dates = candle_dates(response)
+        dates = requested_candle_dates(response, start_date, end_date)
         return false if dates.empty?
 
+        return daily_range_covered?(dates, start_date, end_date) if frequency == "day"
+
         start_date >= dates.first && end_date <= dates.last
-      end
-
-      def missing_ranges(response, start_date, end_date)
-        return [{ start_date: start_date, end_date: end_date }] unless response
-
-        dates = candle_dates(response)
-        return [{ start_date: start_date, end_date: end_date }] if dates.empty?
-
-        ranges = []
-        ranges << { start_date: start_date, end_date: dates.first - 1 } if start_date < dates.first
-        ranges << { start_date: dates.last + 1, end_date: end_date } if end_date > dates.last
-        ranges
       end
 
       def candle_dates(response)
@@ -362,10 +347,22 @@ module SchwabRb
         end.sort
       end
 
+      def requested_candle_dates(response, start_date, end_date)
+        candle_dates(response).select { |date| date >= start_date && date <= end_date }
+      end
+
+      def daily_range_covered?(cached_dates, start_date, end_date)
+        business_dates_in_range(start_date, end_date).all? { |date| cached_dates.include?(date) }
+      end
+
+      def business_dates_in_range(start_date, end_date)
+        (start_date..end_date).select { |date| (1..5).cover?(date.wday) }
+      end
+
       def fetch_price_history_range(client, options, start_date, end_date)
         frequency_config = FREQUENCY_ALIASES.fetch(options[:freq])
         client.get_price_history(
-          options.fetch(:symbol),
+          api_symbol(options.fetch(:symbol)),
           period_type: options[:period_type] || frequency_config.fetch(:period_type),
           period: options[:period] || frequency_config.fetch(:period),
           frequency_type: frequency_config.fetch(:frequency_type),
@@ -376,6 +373,15 @@ module SchwabRb
           need_previous_close: options.fetch(:need_previous_close),
           return_data_objects: false
         )
+      end
+
+      def api_symbol(symbol)
+        raw_symbol = symbol.to_s.strip
+        return raw_symbol if raw_symbol.start_with?("$", "/")
+
+        return "$#{raw_symbol}" if INDEX_API_SYMBOLS.include?(raw_symbol.upcase)
+
+        raw_symbol
       end
 
       # rubocop:disable Metrics/AbcSize, Metrics/CyclomaticComplexity
@@ -491,15 +497,10 @@ module SchwabRb
         raise Error, "Invalid #{option_name} `#{value}`. Use YYYY-MM-DD."
       end
 
-      def build_filename(symbol, frequency, start_date, end_date, format)
-        sanitized_symbol = sanitize_symbol(symbol)
+      def normalized_end_date(end_date)
+        return end_date unless end_date == Date.today
 
-        [
-          sanitized_symbol,
-          frequency,
-          start_date.iso8601,
-          end_date.iso8601
-        ].join("_") + ".#{format}"
+        end_date - 1
       end
 
       def canonical_output_path(directory, options)

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.7.0"
+  VERSION = "0.7.1"
 end

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -62,7 +62,7 @@ describe SchwabRb::CLI::App do
 
         expect(status).to eq(0)
         expect(client).to have_received(:get_price_history).with(
-          "VIX",
+          "$VIX",
           period_type: SchwabRb::PriceHistory::PeriodTypes::DAY,
           period: SchwabRb::PriceHistory::Periods::ONE_DAY,
           frequency_type: SchwabRb::PriceHistory::FrequencyTypes::MINUTE,
@@ -77,6 +77,75 @@ describe SchwabRb::CLI::App do
         expected_path = File.join(dir, "VIX_1min.json")
         expect(File).to exist(expected_path)
         expect(stdout.string).to include(expected_path)
+      end
+    end
+
+    it "uses the index api symbol but keeps the raw symbol in the file name" do
+      Dir.mktmpdir do |dir|
+        client = double("client", session: double("session", expired?: false))
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_price_history).and_return(symbol: "$SPX", candles: [])
+
+        status = app.call(
+          [
+            "price-history",
+            "--symbol", "SPX",
+            "--start-date", "2026-03-17",
+            "--end-date", "2026-03-24",
+            "--freq", "day",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_price_history).with(
+          "$SPX",
+          period_type: SchwabRb::PriceHistory::PeriodTypes::YEAR,
+          period: SchwabRb::PriceHistory::Periods::TWENTY_YEARS,
+          frequency_type: SchwabRb::PriceHistory::FrequencyTypes::DAILY,
+          frequency: SchwabRb::PriceHistory::Frequencies::DAILY,
+          start_datetime: Date.new(2026, 3, 17),
+          end_datetime: Date.new(2026, 3, 24),
+          need_extended_hours_data: false,
+          need_previous_close: false,
+          return_data_objects: false
+        )
+        expect(File).to exist(File.join(dir, "SPX_day.json"))
+      end
+    end
+
+    it "passes futures symbols through to the api unchanged" do
+      Dir.mktmpdir do |dir|
+        client = double("client", session: double("session", expired?: false))
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_price_history).and_return(symbol: "/ES", candles: [])
+
+        status = app.call(
+          [
+            "price-history",
+            "--symbol", "/ES",
+            "--start-date", "2026-03-17",
+            "--end-date", "2026-03-24",
+            "--freq", "day",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_price_history).with(
+          "/ES",
+          period_type: SchwabRb::PriceHistory::PeriodTypes::YEAR,
+          period: SchwabRb::PriceHistory::Periods::TWENTY_YEARS,
+          frequency_type: SchwabRb::PriceHistory::FrequencyTypes::DAILY,
+          frequency: SchwabRb::PriceHistory::Frequencies::DAILY,
+          start_datetime: Date.new(2026, 3, 17),
+          end_datetime: Date.new(2026, 3, 24),
+          need_extended_hours_data: false,
+          need_previous_close: false,
+          return_data_objects: false
+        )
       end
     end
 
@@ -115,6 +184,39 @@ describe SchwabRb::CLI::App do
         output = File.read(File.join(dir, "AAPL_day.csv"))
         expect(output).to include("datetime,open,high,low,close,volume")
         expect(output).to include("2024-03-22T03:33:20Z,100.0,101.0,99.5,100.5,1234")
+      end
+    end
+
+    it "uses yesterday when end date would otherwise be today" do
+      Dir.mktmpdir do |dir|
+        client = double("client", session: double("session", expired?: false))
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_price_history).and_return(symbol: "VIX", candles: [])
+
+        status = app.call(
+          [
+            "price-history",
+            "--symbol", "VIX",
+            "--start-date", (Date.today - 5).iso8601,
+            "--freq", "day",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_price_history).with(
+          "$VIX",
+          period_type: SchwabRb::PriceHistory::PeriodTypes::YEAR,
+          period: SchwabRb::PriceHistory::Periods::TWENTY_YEARS,
+          frequency_type: SchwabRb::PriceHistory::FrequencyTypes::DAILY,
+          frequency: SchwabRb::PriceHistory::Frequencies::DAILY,
+          start_datetime: Date.today - 5,
+          end_datetime: Date.today - 1,
+          need_extended_hours_data: false,
+          need_previous_close: false,
+          return_data_objects: false
+        )
       end
     end
 
@@ -198,13 +300,13 @@ describe SchwabRb::CLI::App do
 
         expect(status).to eq(0)
         expect(client).to have_received(:get_price_history).with(
-          "SPX",
+          "$SPX",
           period_type: SchwabRb::PriceHistory::PeriodTypes::DAY,
           period: SchwabRb::PriceHistory::Periods::ONE_DAY,
           frequency_type: SchwabRb::PriceHistory::FrequencyTypes::MINUTE,
           frequency: SchwabRb::PriceHistory::Frequencies::EVERY_FIVE_MINUTES,
           start_datetime: Date.new(2026, 3, 17),
-          end_datetime: Date.new(2026, 3, 19),
+          end_datetime: Date.new(2026, 3, 24),
           need_extended_hours_data: false,
           need_previous_close: false,
           return_data_objects: false
@@ -221,6 +323,122 @@ describe SchwabRb::CLI::App do
         expect(
           merged_output.fetch("candles").find { |candle| candle.fetch("datetime") == Time.utc(2026, 3, 20, 14, 30).to_i * 1000 }
         ).to include("open" => 99)
+      end
+    end
+
+    it "fetches missing interior daily dates and merges them into the cache" do
+      Dir.mktmpdir do |dir|
+        cached_path = File.join(dir, "VIX_day.csv")
+        File.write(
+          cached_path,
+          <<~CSV
+            datetime,open,high,low,close,volume
+            2026-04-01T00:00:00Z,10.0,11.0,9.0,10.5,100
+            2026-04-03T00:00:00Z,12.0,13.0,11.0,12.5,120
+          CSV
+        )
+
+        client = double("client", session: double("session", expired?: false))
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_price_history).and_return(
+          {
+            symbol: "VIX",
+            candles: [
+              { datetime: Time.utc(2026, 4, 2).to_i * 1000, open: 11.0, high: 12.0, low: 10.0, close: 11.5, volume: 110 }
+            ]
+          }
+        )
+
+        status = app.call(
+          [
+            "price-history",
+            "--symbol", "VIX",
+            "--start-date", "2026-04-01",
+            "--end-date", "2026-04-03",
+            "--freq", "day",
+            "--format", "csv",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_price_history).with(
+          "$VIX",
+          period_type: SchwabRb::PriceHistory::PeriodTypes::YEAR,
+          period: SchwabRb::PriceHistory::Periods::TWENTY_YEARS,
+          frequency_type: SchwabRb::PriceHistory::FrequencyTypes::DAILY,
+          frequency: SchwabRb::PriceHistory::Frequencies::DAILY,
+          start_datetime: Date.new(2026, 4, 1),
+          end_datetime: Date.new(2026, 4, 3),
+          need_extended_hours_data: false,
+          need_previous_close: false,
+          return_data_objects: false
+        )
+
+        output = File.read(cached_path)
+        expect(output).to include("2026-04-01T00:00:00Z,10.0,11.0,9.0,10.5,100")
+        expect(output).to include("2026-04-02T00:00:00Z,11.0,12.0,10.0,11.5,110")
+        expect(output).to include("2026-04-03T00:00:00Z,12.0,13.0,11.0,12.5,120")
+      end
+    end
+
+    it "treats a requested window with no cached overlap as fully missing" do
+      Dir.mktmpdir do |dir|
+        cached_path = File.join(dir, "VIX_day.csv")
+        File.write(
+          cached_path,
+          <<~CSV
+            datetime,open,high,low,close,volume
+            2026-03-20T00:00:00Z,20.0,21.0,19.0,20.5,100
+            2026-03-23T00:00:00Z,23.0,24.0,22.0,23.5,130
+          CSV
+        )
+
+        client = double("client", session: double("session", expired?: false))
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_price_history).and_return(
+          {
+            symbol: "VIX",
+            candles: [
+              { datetime: Time.utc(2026, 4, 1).to_i * 1000, open: 30.0, high: 31.0, low: 29.0, close: 30.5, volume: 140 },
+              { datetime: Time.utc(2026, 4, 2).to_i * 1000, open: 31.0, high: 32.0, low: 30.0, close: 31.5, volume: 150 }
+            ]
+          }
+        )
+
+        status = app.call(
+          [
+            "price-history",
+            "--symbol", "VIX",
+            "--start-date", "2026-04-01",
+            "--end-date", "2026-04-02",
+            "--freq", "day",
+            "--format", "csv",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_price_history).with(
+          "$VIX",
+          period_type: SchwabRb::PriceHistory::PeriodTypes::YEAR,
+          period: SchwabRb::PriceHistory::Periods::TWENTY_YEARS,
+          frequency_type: SchwabRb::PriceHistory::FrequencyTypes::DAILY,
+          frequency: SchwabRb::PriceHistory::Frequencies::DAILY,
+          start_datetime: Date.new(2026, 4, 1),
+          end_datetime: Date.new(2026, 4, 2),
+          need_extended_hours_data: false,
+          need_previous_close: false,
+          return_data_objects: false
+        )
+
+        output = File.read(cached_path)
+        expect(output).to include("2026-03-20T00:00:00Z,20.0,21.0,19.0,20.5,100")
+        expect(output).to include("2026-03-23T00:00:00Z,23.0,24.0,22.0,23.5,130")
+        expect(output).to include("2026-04-01T00:00:00Z,30.0,31.0,29.0,30.5,140")
+        expect(output).to include("2026-04-02T00:00:00Z,31.0,32.0,30.0,31.5,150")
       end
     end
 


### PR DESCRIPTION
## Summary
- normalize CLI price history symbols for Schwab API requests while keeping raw symbols in local file names
- simplify cache reconciliation to a single request when the requested range is not fully present locally
- normalize end date from today to yesterday and bump the gem version to 0.7.1

## Testing
- bundle exec rspec spec/cli/app_spec.rb
- bundle exec rubocop --cache false lib/schwab_rb/cli/app.rb spec/cli/app_spec.rb lib/schwab_rb/version.rb