### PR TITLE
Add option sample CLI command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Added
+- CLI `sample` command for saving single-expiration option chain snapshots as CSV or JSON
+- `--root` option for filtering sampled contracts by option root and using that root in output filenames
+
+### Changed
+- CLI history downloads now default to `~/.schwab_rb/data/history`
+- CLI option samples now default to `~/.schwab_rb/data/options`
+
 ## [0.6.0] - 2025-12-11
 
 ### Breaking Changes

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schwab_rb (0.7.1)
+    schwab_rb (0.8.0)
       async (~> 2.18)
       async-http (~> 0.82)
       dotenv

--- a/lib/schwab_rb/cli/app.rb
+++ b/lib/schwab_rb/cli/app.rb
@@ -15,11 +15,39 @@ module SchwabRb
     # Minimal command dispatcher for the gem's built-in CLI.
     # rubocop:disable Metrics/ClassLength
     class App
-      DEFAULT_DATA_DIR = "~/.schwab_rb/data"
+      DEFAULT_HISTORY_DIR = "~/.schwab_rb/data/history"
+      DEFAULT_OPTIONS_DIR = "~/.schwab_rb/data/options"
       INDEX_API_SYMBOLS = %w[
         COMPX DJX MID NDX OEX RUT SPX VIX VIX9D VIX1D XSP
       ].freeze
       SUPPORTED_FORMATS = %w[csv json].freeze
+      OPTION_SAMPLE_CSV_HEADERS = %w[
+        contract_type
+        symbol
+        description
+        strike
+        expiration_date
+        mark
+        bid
+        bid_size
+        ask
+        ask_size
+        last
+        last_size
+        open_interest
+        total_volume
+        delta
+        gamma
+        theta
+        vega
+        rho
+        volatility
+        theoretical_volatility
+        theoretical_option_value
+        intrinsic_value
+        extrinsic_value
+        underlying_price
+      ].freeze
       PERIOD_TYPES = {
         "day" => SchwabRb::PriceHistory::PeriodTypes::DAY,
         "month" => SchwabRb::PriceHistory::PeriodTypes::MONTH,
@@ -101,6 +129,8 @@ module SchwabRb
           handle_login(argv)
         when "price-history"
           handle_price_history(argv)
+        when "sample"
+          handle_option_sample(argv)
         else
           print_error("Unknown command `#{command}`.\n\n#{root_help}")
           1
@@ -124,6 +154,8 @@ module SchwabRb
           stdout.puts(login_help)
         when "price-history"
           stdout.puts(price_history_help)
+        when "sample"
+          stdout.puts(option_sample_help)
         else
           raise Error, "Unknown help topic `#{topic}`."
         end
@@ -164,7 +196,7 @@ module SchwabRb
       # rubocop:disable Metrics/AbcSize
       def handle_price_history(argv)
         options = {
-          dir: default_data_dir,
+          dir: default_history_dir,
           end_date: Date.today,
           format: "json",
           freq: "day",
@@ -176,7 +208,7 @@ module SchwabRb
         parser = OptionParser.new do |opts|
           opts.banner = price_history_help
           opts.on("-s", "--symbol SYMBOL", "Ticker symbol to download") { |value| options[:symbol] = value }
-          opts.on("--dir DIRECTORY", "Output directory (default: #{DEFAULT_DATA_DIR})") do |value|
+          opts.on("--dir DIRECTORY", "Output directory (default: #{DEFAULT_HISTORY_DIR})") do |value|
             options[:dir] = value
           end
           opts.on("--start-date DATE", "Start date in YYYY-MM-DD format") do |value|
@@ -220,9 +252,45 @@ module SchwabRb
       # rubocop:enable Metrics/AbcSize
 
       # rubocop:disable Metrics/AbcSize
+      def handle_option_sample(argv)
+        options = {
+          dir: default_options_dir,
+          format: "csv",
+          timestamp: Time.now
+        }
+
+        parser = OptionParser.new do |opts|
+          opts.banner = option_sample_help
+          opts.on("-s", "--symbol SYMBOL", "Ticker symbol to sample") { |value| options[:symbol] = value }
+          opts.on("--root ROOT", "Option root to filter and use in the output filename") do |value|
+            options[:root] = value
+          end
+          opts.on("--expiration-date DATE", "Expiration date in YYYY-MM-DD format") do |value|
+            options[:expiration_date] = parse_date(value, "expiration-date")
+          end
+          opts.on("--dir DIRECTORY", "Output directory (default: #{DEFAULT_OPTIONS_DIR})") do |value|
+            options[:dir] = value
+          end
+          opts.on("--format FORMAT", "Output format: #{SUPPORTED_FORMATS.join(', ')}") do |value|
+            options[:format] = normalize_format(value)
+          end
+        end
+
+        parser.parse!(argv)
+        raise Error, "Unexpected arguments: #{argv.join(' ')}" if argv.any?
+
+        validate_option_sample_options!(options)
+
+        output_path = resolve_option_sample_response(options)
+
+        stdout.puts("Saved #{options[:symbol]} option sample to #{output_path}")
+        0
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      # rubocop:disable Metrics/AbcSize
       def resolve_price_history_response(options)
         directory = SchwabRb::PathSupport.expand_path(options.fetch(:dir))
-        FileUtils.mkdir_p(directory)
 
         existing_response = load_cached_price_history(directory, options)
         response = existing_response
@@ -234,6 +302,7 @@ module SchwabRb
           options.fetch(:freq)
         )
           client = build_non_interactive_client
+          FileUtils.mkdir_p(directory)
           downloaded = fetch_price_history_range(
             client,
             options,
@@ -252,6 +321,19 @@ module SchwabRb
 
       def write_payload(output_path, response, format)
         File.write(output_path, serialized_payload(response, format))
+      end
+
+      def resolve_option_sample_response(options)
+        directory = SchwabRb::PathSupport.expand_path(options.fetch(:dir))
+        response = fetch_option_sample(build_non_interactive_client, options)
+        FileUtils.mkdir_p(directory)
+        output_path = option_sample_output_path(directory, options, response)
+        write_option_sample(output_path, response, options)
+        output_path
+      end
+
+      def write_option_sample(output_path, response, options)
+        File.write(output_path, serialized_option_sample(response, options))
       end
 
       # rubocop:disable Metrics/AbcSize
@@ -276,6 +358,60 @@ module SchwabRb
         else
           raise Error, "Unsupported format `#{format}`."
         end
+      end
+      # rubocop:enable Metrics/AbcSize
+
+      def serialized_option_sample(response, options)
+        case options.fetch(:format)
+        when "json"
+          JSON.pretty_generate(response)
+        when "csv"
+          serialized_option_sample_csv(response, options)
+        else
+          raise Error, "Unsupported format `#{options[:format]}`."
+        end
+      end
+
+      def serialized_option_sample_csv(response, options)
+        sample_timestamp = options.fetch(:timestamp).utc.iso8601
+
+        CSV.generate do |csv|
+          csv << OPTION_SAMPLE_CSV_HEADERS
+          option_sample_rows(response).each do |option|
+            csv << option_sample_csv_row(response, option, sample_timestamp)
+          end
+        end
+      end
+
+      # rubocop:disable Metrics/AbcSize
+      def option_sample_csv_row(response, option, _sample_timestamp)
+        [
+          option[:putCall],
+          option[:symbol],
+          option[:description],
+          option[:strikePrice],
+          normalize_option_date(option[:expirationDate]),
+          option[:mark],
+          option[:bid],
+          option[:bidSize],
+          option[:ask],
+          option[:askSize],
+          option[:last],
+          option[:lastSize],
+          option[:openInterest],
+          option[:totalVolume],
+          option[:delta],
+          option[:gamma],
+          option[:theta],
+          option[:vega],
+          option[:rho],
+          option[:volatility],
+          option[:theoreticalVolatility],
+          option[:theoreticalOptionValue],
+          option[:intrinsicValue],
+          option[:extrinsicValue],
+          response[:underlyingPrice]
+        ]
       end
       # rubocop:enable Metrics/AbcSize
 
@@ -375,6 +511,79 @@ module SchwabRb
         )
       end
 
+      def fetch_option_sample(client, options)
+        expiration_date = options.fetch(:expiration_date)
+
+        response = client.get_option_chain(
+          api_symbol(options.fetch(:symbol)),
+          contract_type: SchwabRb::Option::ContractTypes::ALL,
+          strike_range: SchwabRb::Option::StrikeRanges::ALL,
+          from_date: expiration_date,
+          to_date: expiration_date,
+          return_data_objects: false
+        )
+
+        filter_option_sample_response(response, options[:root])
+      end
+
+      def option_sample_rows(response)
+        rows = [response[:callExpDateMap], response[:putExpDateMap]].compact.flat_map do |date_map|
+          option_rows_from_date_map(date_map)
+        end
+
+        rows.sort_by do |option|
+          [
+            normalize_option_date(option[:expirationDate]).to_s,
+            option[:putCall].to_s,
+            option[:strikePrice].to_f
+          ]
+        end
+      end
+
+      def option_rows_from_date_map(date_map)
+        date_map.values.flat_map do |strikes|
+          strikes.values.flatten.map { |option| option.transform_keys(&:to_sym) }
+        end
+      end
+
+      def filter_option_sample_response(response, option_root)
+        return response if blank?(option_root)
+
+        normalized_root = option_root.to_s.strip.upcase
+        filtered_call_map = filter_option_date_map_by_root(response[:callExpDateMap], normalized_root)
+        filtered_put_map = filter_option_date_map_by_root(response[:putExpDateMap], normalized_root)
+
+        response.merge(
+          callExpDateMap: filtered_call_map,
+          putExpDateMap: filtered_put_map
+        )
+      end
+
+      def filter_option_date_map_by_root(date_map, option_root)
+        return {} unless date_map
+
+        date_map.each_with_object({}) do |(expiration_key, strikes), filtered_dates|
+          filtered_strikes = strikes.each_with_object({}) do |(strike, contracts), filtered_by_strike|
+            matching_contracts = contracts.select { |contract| contract[:optionRoot].to_s.upcase == option_root }
+            filtered_by_strike[strike] = matching_contracts if matching_contracts.any?
+          end
+
+          filtered_dates[expiration_key] = filtered_strikes if filtered_strikes.any?
+        end
+      end
+
+      def normalize_option_date(value)
+        return if value.nil?
+
+        Date.parse(value.to_s).iso8601
+      end
+
+      def normalize_option_timestamp(value)
+        return if value.nil?
+
+        Time.at(value / 1000.0).utc.iso8601
+      end
+
       def api_symbol(symbol)
         raw_symbol = symbol.to_s.strip
         return raw_symbol if raw_symbol.start_with?("$", "/")
@@ -461,13 +670,22 @@ module SchwabRb
         raise Error, "`--end-date` must be on or after `--start-date`."
       end
 
+      def validate_option_sample_options!(options)
+        raise Error, "The `--symbol` option is required." if blank?(options[:symbol])
+        raise Error, "The `--expiration-date` option is required." unless options[:expiration_date]
+      end
+
       def resolved_token_path
         token_path = env["SCHWAB_TOKEN_PATH"] || env["TOKEN_PATH"] || SchwabRb::Constants::DEFAULT_TOKEN_PATH
         SchwabRb::PathSupport.expand_path(token_path)
       end
 
-      def default_data_dir
-        SchwabRb::PathSupport.expand_path(DEFAULT_DATA_DIR)
+      def default_history_dir
+        SchwabRb::PathSupport.expand_path(DEFAULT_HISTORY_DIR)
+      end
+
+      def default_options_dir
+        SchwabRb::PathSupport.expand_path(DEFAULT_OPTIONS_DIR)
       end
 
       def normalize_format(value)
@@ -510,6 +728,22 @@ module SchwabRb
         )
       end
 
+      def option_sample_output_path(directory, options, response)
+        File.join(
+          directory,
+          [
+            sanitize_symbol(options[:root] || option_sample_root(response, options.fetch(:symbol))),
+            "exp#{options.fetch(:expiration_date).iso8601}",
+            options.fetch(:timestamp).strftime("%Y-%m-%d_%H-%M-%S")
+          ].join("_") + ".#{options.fetch(:format)}"
+        )
+      end
+
+      def option_sample_root(response, fallback_symbol)
+        first_option = option_sample_rows(response).find { |option| !blank?(option[:optionRoot]) }
+        first_option ? first_option[:optionRoot] : fallback_symbol
+      end
+
       def sanitize_symbol(symbol)
         sanitized_symbol = symbol.to_s.gsub(/[^a-zA-Z0-9]+/, "_").gsub(/\A_+|_+\z/, "")
         sanitized_symbol = "symbol" if sanitized_symbol.empty?
@@ -532,6 +766,7 @@ module SchwabRb
             help [command]   Show general or command-specific help
             login            Authenticate and store a shared Schwab token
             price-history    Download price history data to disk
+            sample           Download an option-chain sample for one expiration
         HELP
       end
 
@@ -550,7 +785,7 @@ module SchwabRb
 
           Options:
             -s, --symbol SYMBOL                    Ticker symbol to download
-                --dir DIRECTORY                    Output directory (default: #{DEFAULT_DATA_DIR})
+                --dir DIRECTORY                    Output directory (default: #{DEFAULT_HISTORY_DIR})
                 --start-date DATE                 Start date in YYYY-MM-DD format
                 --end-date DATE                   End date in YYYY-MM-DD format (default: today)
             -p, --period PERIOD                   Period value passed through to the API
@@ -559,6 +794,21 @@ module SchwabRb
                 --[no-]need-extended-hours-data  Include extended hours data (default: false)
                 --[no-]need-previous-close       Include previous close data (default: false)
                 --format FORMAT                  Output format: #{SUPPORTED_FORMATS.join(', ')} (default: json)
+        HELP
+      end
+
+      def option_sample_help
+        <<~HELP
+          Usage: schwab_rb sample --symbol SYMBOL --expiration-date YYYY-MM-DD [options]
+
+          Downloads the full option chain for a single expiration and writes a timestamped sample file.
+
+          Options:
+            -s, --symbol SYMBOL          Underlying symbol to sample
+                --root ROOT              Option root to filter and use in the output filename
+                --expiration-date DATE   Expiration date in YYYY-MM-DD format
+                --dir DIRECTORY          Output directory (default: #{DEFAULT_OPTIONS_DIR})
+                --format FORMAT          Output format: #{SUPPORTED_FORMATS.join(', ')} (default: csv)
         HELP
       end
     end

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end

--- a/spec/cli/app_spec.rb
+++ b/spec/cli/app_spec.rb
@@ -7,6 +7,7 @@ require "tmpdir"
 describe SchwabRb::CLI::App do
   let(:stdout) { StringIO.new }
   let(:stderr) { StringIO.new }
+  let(:sampled_at) { Time.utc(2025, 12, 29, 17, 24, 33) }
   let(:env) do
     {
       "SCHWAB_API_KEY" => "api-key",
@@ -24,6 +25,7 @@ describe SchwabRb::CLI::App do
       expect(status).to eq(0)
       expect(stdout.string).to include("Usage: schwab_rb COMMAND [options]")
       expect(stdout.string).to include("price-history")
+      expect(stdout.string).to include("sample")
     end
 
     it "passes the shared token path to login" do
@@ -78,6 +80,31 @@ describe SchwabRb::CLI::App do
         expect(File).to exist(expected_path)
         expect(stdout.string).to include(expected_path)
       end
+    end
+
+    it "uses the history directory by default for price history" do
+      client = double("client", session: double("session", expired?: false))
+      allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+      allow(client).to receive(:refresh!)
+      allow(client).to receive(:get_price_history).and_return(symbol: "AAPL", candles: [])
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(File).to receive(:exist?).and_return(false)
+      allow(File).to receive(:write)
+
+      status = app.call(
+        [
+          "price-history",
+          "--symbol", "AAPL",
+          "--start-date", "2026-03-17"
+        ]
+      )
+
+      expect(status).to eq(0)
+      expect(FileUtils).to have_received(:mkdir_p).with(File.expand_path("~/.schwab_rb/data/history"))
+      expect(File).to have_received(:write).with(
+        File.expand_path("~/.schwab_rb/data/history/AAPL_day.json"),
+        kind_of(String)
+      )
     end
 
     it "uses the index api symbol but keeps the raw symbol in the file name" do
@@ -455,6 +482,206 @@ describe SchwabRb::CLI::App do
 
       expect(status).to eq(1)
       expect(stderr.string).to include("Run `schwab_rb login`")
+    end
+
+    it "writes a csv option sample for one expiration" do
+      Dir.mktmpdir do |dir|
+        client = double("client", session: double("session", expired?: false))
+        allow(Time).to receive(:now).and_return(sampled_at)
+        allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+        allow(client).to receive(:refresh!)
+        allow(client).to receive(:get_option_chain).and_return(
+          {
+            symbol: "$SPX",
+            status: "SUCCESS",
+            callExpDateMap: {
+              "2025-12-29:0" => {
+                "6000.0" => [
+                  {
+                    symbol: "SPX  251229C06000000",
+                    expirationDate: "2025-12-29T06:00:00+0000",
+                    putCall: "CALL",
+                    optionRoot: "SPX",
+                    strikePrice: 6000.0,
+                    bid: 99.0,
+                    bidSize: 1,
+                    ask: 100.0,
+                    askSize: 1,
+                    last: 99.5,
+                    lastSize: 1,
+                    mark: 99.5,
+                    delta: 0.5,
+                    gamma: 0.01,
+                    theta: -0.1,
+                    vega: 0.1,
+                    rho: 0.01,
+                    volatility: 10.0,
+                    theoreticalVolatility: 10.0,
+                    theoreticalOptionValue: 99.5,
+                    intrinsicValue: 0.0,
+                    extrinsicValue: 99.5,
+                    totalVolume: 1,
+                    openInterest: 1,
+                    description: "SPX Dec 29 2025 6000 Call"
+                  },
+                  {
+                    symbol: "SPXW  251229C06000000",
+                    expirationDate: "2025-12-29T06:00:00+0000",
+                    putCall: "CALL",
+                    optionRoot: "SPXW",
+                    strikePrice: 6000.0,
+                    bid: 10.0,
+                    bidSize: 12,
+                    ask: 10.5,
+                    askSize: 14,
+                    last: 10.25,
+                    lastSize: 3,
+                    mark: 10.25,
+                    delta: 0.42,
+                    gamma: 0.01,
+                    theta: -0.2,
+                    vega: 0.15,
+                    rho: 0.03,
+                    volatility: 18.5,
+                    theoreticalVolatility: 19.0,
+                    theoreticalOptionValue: 10.4,
+                    intrinsicValue: 0.0,
+                    extrinsicValue: 10.25,
+                    totalVolume: 100,
+                    openInterest: 200,
+                    quoteTimeInLong: 1_767_029_073_000,
+                    tradeTimeInLong: 1_767_029_000_000,
+                    daysToExpiration: 0,
+                    inTheMoney: false,
+                    description: "SPXW Dec 29 2025 6000 Call"
+                  }
+                ]
+              }
+            },
+            putExpDateMap: {
+              "2025-12-29:0" => {
+                "6000.0" => [
+                  {
+                    symbol: "SPXW  251229P06000000",
+                    expirationDate: "2025-12-29T06:00:00+0000",
+                    putCall: "PUT",
+                    optionRoot: "SPXW",
+                    strikePrice: 6000.0,
+                    bid: 11.0,
+                    bidSize: 8,
+                    ask: 11.5,
+                    askSize: 9,
+                    last: 11.25,
+                    lastSize: 2,
+                    mark: 11.25,
+                    delta: -0.58,
+                    gamma: 0.02,
+                    theta: -0.25,
+                    vega: 0.18,
+                    rho: -0.04,
+                    volatility: 19.1,
+                    theoreticalVolatility: 19.4,
+                    theoreticalOptionValue: 11.3,
+                    intrinsicValue: 3.5,
+                    extrinsicValue: 7.75,
+                    totalVolume: 150,
+                    openInterest: 250,
+                    quoteTimeInLong: 1_767_029_073_000,
+                    tradeTimeInLong: 1_767_029_000_000,
+                    daysToExpiration: 0,
+                    inTheMoney: true,
+                    description: "SPXW Dec 29 2025 6000 Put"
+                  }
+                ]
+              }
+            },
+            underlyingPrice: 5996.5
+          }
+        )
+
+        status = app.call(
+          [
+            "sample",
+            "--symbol", "SPX",
+            "--root", "SPXW",
+            "--expiration-date", "2025-12-29",
+            "--dir", dir
+          ]
+        )
+
+        expect(status).to eq(0)
+        expect(client).to have_received(:get_option_chain).with(
+          "$SPX",
+          contract_type: SchwabRb::Option::ContractTypes::ALL,
+          strike_range: SchwabRb::Option::StrikeRanges::ALL,
+          from_date: Date.new(2025, 12, 29),
+          to_date: Date.new(2025, 12, 29),
+          return_data_objects: false
+        )
+
+        expected_path = File.join(dir, "SPXW_exp2025-12-29_2025-12-29_17-24-33.csv")
+        expect(File).to exist(expected_path)
+        output = File.read(expected_path)
+        expect(output).to include(
+          "contract_type,symbol,description,strike,expiration_date,mark,bid,bid_size,ask,ask_size,last,last_size," \
+          "open_interest,total_volume,delta,gamma,theta,vega,rho,volatility,theoretical_volatility," \
+          "theoretical_option_value,intrinsic_value,extrinsic_value,underlying_price"
+        )
+        expect(output).to include(
+          "CALL,SPXW  251229C06000000,SPXW Dec 29 2025 6000 Call,6000.0,2025-12-29,10.25,10.0,12,10.5,14,10.25,3," \
+          "200,100,0.42,0.01,-0.2,0.15,0.03,18.5,19.0,10.4,0.0,10.25,5996.5"
+        )
+        expect(output).to include(
+          "PUT,SPXW  251229P06000000,SPXW Dec 29 2025 6000 Put,6000.0,2025-12-29,11.25,11.0,8,11.5,9,11.25,2," \
+          "250,150,-0.58,0.02,-0.25,0.18,-0.04,19.1,19.4,11.3,3.5,7.75,5996.5"
+        )
+        expect(output).not_to include("SPX  251229C06000000")
+      end
+    end
+
+    it "writes json option samples to the options directory by default" do
+      client = double("client", session: double("session", expired?: false))
+      allow(Time).to receive(:now).and_return(sampled_at)
+      allow(SchwabRb::Auth).to receive(:init_client_token_file).and_return(client)
+      allow(client).to receive(:refresh!)
+      allow(client).to receive(:get_option_chain).and_return(
+        {
+          symbol: "AAPL",
+          status: "SUCCESS",
+          callExpDateMap: {},
+          putExpDateMap: {}
+        }
+      )
+      allow(FileUtils).to receive(:mkdir_p)
+      allow(File).to receive(:write)
+
+      status = app.call(
+        [
+          "sample",
+          "--symbol", "AAPL",
+          "--expiration-date", "2025-12-29",
+          "--format", "json"
+        ]
+      )
+
+      expect(status).to eq(0)
+      expect(FileUtils).to have_received(:mkdir_p).with(File.expand_path("~/.schwab_rb/data/options"))
+      expect(File).to have_received(:write).with(
+        File.expand_path("~/.schwab_rb/data/options/AAPL_exp2025-12-29_2025-12-29_17-24-33.json"),
+        kind_of(String)
+      )
+    end
+
+    it "requires an expiration date for option samples" do
+      status = app.call(
+        [
+          "sample",
+          "--symbol", "SPX"
+        ]
+      )
+
+      expect(status).to eq(1)
+      expect(stderr.string).to include("The `--expiration-date` option is required.")
     end
   end
 end


### PR DESCRIPTION
## Summary
- add a sample CLI command for single-expiration option chain snapshots in CSV or JSON
- support the --root option so the CLI fetches by underlying symbol and filters/names output by option root
- move default CLI data directories to ~/.schwab_rb/data/history and ~/.schwab_rb/data/options, and bump the gem version to 0.8.0

## Testing
- bundle exec rspec spec/cli/app_spec.rb
- bundle exec rubocop --cache false lib/schwab_rb/cli/app.rb spec/cli/app_spec.rb