### PR TITLE
Default logs to ~/.schwab_rb and bump version to 0.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schwab_rb (0.8.0)
+    schwab_rb (0.8.2)
       async (~> 2.18)
       async-http (~> 0.82)
       dotenv

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Before using the gem, ensure you have the following environment variables set:
 - `APP_CALLBACK_URL`: The callback URL for your application.
 - `TOKEN_PATH`: Path to store the authentication token.
 - `SCHWAB_ACCOUNT_NUMBER`: Your Schwab account number.
-- `SCHWAB_LOGFILE`: (Optional) Path to the log file. Defaults to `STDOUT`.
+- `SCHWAB_LOGFILE`: (Optional) Path to the log file. Defaults to `~/.schwab_rb/schwab_rb.log`.
 - `SCHWAB_LOG_LEVEL`: (Optional) Log level for the logger. Defaults to `WARN`. Possible values: `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL`.
 - `SCHWAB_SILENCE_OUTPUT`: (Optional) Set to `true` to disable logging output. Defaults to `false`.
 
@@ -91,7 +91,7 @@ You can also configure logging programmatically:
 
 ```ruby
 SchwabRb.configure do |config|
-  config.logger = Logger.new(STDOUT)
+  config.logger = Logger.new($stdout)
   config.log_level = 'INFO'
   config.silence_output = false
 end

--- a/lib/schwab_rb/configuration.rb
+++ b/lib/schwab_rb/configuration.rb
@@ -25,8 +25,14 @@ module SchwabRb
       !has_external_logger? && !@silence_output
     end
 
+    def default_log_file
+      File.join(@schwab_home, "schwab_rb.log")
+    end
+
     def effective_log_file
-      @log_file || (ENV["LOGFILE"] if ENV["LOGFILE"] && !ENV["LOGFILE"].empty?)
+      @log_file ||
+        (ENV["LOGFILE"] if ENV["LOGFILE"] && !ENV["LOGFILE"].empty?) ||
+        default_log_file
     end
   end
 

--- a/lib/schwab_rb/utils/logger.rb
+++ b/lib/schwab_rb/utils/logger.rb
@@ -27,7 +27,7 @@ module SchwabRb
         return null_logger if config.silence_output
         return null_logger unless config.should_create_logger?
 
-        log_destination = config.effective_log_file || $stdout
+        log_destination = config.effective_log_file
 
         return null_logger if [:null, "/dev/null"].include?(log_destination)
 

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/spec/utils/logger_spec.rb
+++ b/spec/utils/logger_spec.rb
@@ -5,20 +5,27 @@ require "fileutils"
 require_relative "../../lib/schwab_rb"
 
 describe SchwabRb::Logger do
-  let(:log_file) { "tmp/test.log" }
+  let(:schwab_home) { File.expand_path("tmp/schwab_home") }
+  let(:log_file) { File.join(schwab_home, "custom.log") }
+  let(:default_log_file) { File.join(schwab_home, "schwab_rb.log") }
 
   before do
-    FileUtils.mkdir_p("tmp") # Ensure tmp directory exists
+    FileUtils.mkdir_p("tmp")
+    FileUtils.rm_rf(schwab_home)
     ENV["SCHWAB_LOGFILE"] = log_file
     ENV["SCHWAB_LOG_LEVEL"] = "DEBUG"
+    ENV["SCHWAB_HOME"] = schwab_home
     SchwabRb.reset_configuration! # Reset configuration AFTER setting env vars
     SchwabRb::Logger.instance_variable_set(:@logger, nil)
   end
 
   after do
-    FileUtils.rm_f(log_file)
+    FileUtils.rm_rf(schwab_home)
     ENV.delete("SCHWAB_LOGFILE")
     ENV.delete("SCHWAB_LOG_LEVEL")
+    ENV.delete("SCHWAB_HOME")
+    SchwabRb.reset_configuration!
+    SchwabRb::Logger.instance_variable_set(:@logger, nil)
   end
 
   it "creates a logger instance" do
@@ -49,8 +56,16 @@ describe SchwabRb::Logger do
     expect(logger.level).to eq(Logger::WARN)
   end
 
-  it "defaults to STDOUT if SCHWAB_LOGFILE is not set" do
+  it "defaults to a log file under SCHWAB_HOME if SCHWAB_LOGFILE is not set" do
     ENV.delete("SCHWAB_LOGFILE")
-    expect { SchwabRb::Logger.logger.info("Test STDOUT log") }.not_to raise_error
+    SchwabRb::Logger.instance_variable_set(:@logger, nil)
+    SchwabRb.reset_configuration!
+
+    logger = SchwabRb::Logger.logger
+    logger.info("Test default log")
+
+    expect(SchwabRb.configuration.effective_log_file).to eq(default_log_file)
+    expect(File.exist?(default_log_file)).to be true
+    expect(File.read(default_log_file)).to include("Test default log")
   end
 end


### PR DESCRIPTION
## Summary
- default logging to ~/.schwab_rb/schwab_rb.log when no explicit log file is configured
- preserve explicit logger, SCHWAB_LOGFILE, LOGFILE, and silence behavior
- bump the gem patch version to 0.8.2

## Testing
- bundle exec rspec spec/utils/logger_spec.rb