### PR TITLE
Fix CLI login prompt and bump version to 0.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+### Fixed
+- CLI `login` no longer reads from `ARGF` at the browser prompt, which prevented `schwab_rb login` from opening the browser when command arguments were present
+
 ### Added
 - CLI `sample` command for saving single-expiration option chain snapshots as CSV or JSON
 - `--root` option for filtering sampled contracts by option root and using that root in output filenames

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    schwab_rb (0.8.2)
+    schwab_rb (0.9.1)
       async (~> 2.18)
       async-http (~> 0.82)
       dotenv

--- a/lib/schwab_rb/auth/init_client_login.rb
+++ b/lib/schwab_rb/auth/init_client_login.rb
@@ -70,6 +70,7 @@ module SchwabRb
       enforce_enums: false,
       callback_timeout: 300.0,
       interactive: true,
+      input: $stdin,
       requested_browser: nil
     )
       token_path = SchwabRb::PathSupport.expand_path(token_path)
@@ -130,7 +131,7 @@ module SchwabRb
 
         if interactive
           puts "Press ENTER to open the browser..."
-          gets
+          input.gets
         end
 
         open_browser(requested_browser, auth_context.authorization_url)

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.9.0"
+  VERSION = "0.9.1"
 end

--- a/spec/auth/init_client_login_spec.rb
+++ b/spec/auth/init_client_login_spec.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "spec_helper"
+require "stringio"
 
 describe SchwabRb::Auth do
   describe ".build_auth_context" do
@@ -107,6 +108,46 @@ describe SchwabRb::Auth do
         )
         puts client
       end.to_not raise_error
+    end
+  end
+
+  describe ".init_client_login" do
+    it "reads the enter prompt from the provided input instead of ARGF" do
+      cert_file = instance_double(Tempfile, path: "/tmp/cert.pem")
+      key_file = instance_double(Tempfile, path: "/tmp/key.pem")
+      auth_context = instance_double(SchwabRb::Auth::AuthContext, authorization_url: "https://example.com/auth")
+      queue = instance_double(Thread::Queue, empty?: false, pop: "https://127.0.0.1:8182?code=abc")
+      http = instance_double(Net::HTTP)
+      response = Net::HTTPSuccess.new("1.1", "200", "OK")
+      input = StringIO.new("\n")
+
+      allow(described_class).to receive(:create_ssl_certificate).and_return([cert_file, key_file])
+      allow(SchwabRb::Auth::LoginFlowServer).to receive(:run_in_thread)
+      allow(SchwabRb::Auth::LoginFlowServer).to receive(:stop)
+      allow(SchwabRb::Auth::LoginFlowServer).to receive(:queue).and_return(queue)
+      allow(described_class).to receive(:build_auth_context).and_return(auth_context)
+      allow(described_class).to receive(:open_browser)
+      allow(described_class).to receive(:client_from_received_url).and_return(:client)
+      allow(Net::HTTP).to receive(:new).and_return(http)
+      allow(http).to receive(:use_ssl=)
+      allow(http).to receive(:ca_file=)
+      allow(http).to receive(:set_debug_output)
+      allow(http).to receive(:get).and_return(response)
+
+      original_argv = ARGV.dup
+      ARGV.replace(["login"])
+
+      expect(
+        described_class.init_client_login(
+          "api-key",
+          "app-secret",
+          "https://127.0.0.1:8182",
+          "/tmp/token.json",
+          input: input
+        )
+      ).to eq(:client)
+    ensure
+      ARGV.replace(original_argv || [])
     end
   end
 end


### PR DESCRIPTION
## Summary
- fix the CLI login prompt to read from stdin instead of ARGF so `schwab_rb login` no longer raises `Errno::ENOENT`
- add a regression spec covering login when ARGV contains the command name
- bump the gem version to 0.9.1 and note the fix in the changelog

## Testing
- bundle exec rspec spec/auth/init_client_login_spec.rb spec/cli/app_spec.rb