### PR TITLE
[codex] Fix option expiration chain symbol keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Fixed
 - CLI `login` no longer reads from `ARGF` at the browser prompt, which prevented `schwab_rb login` from opening the browser when command arguments were present
+- `OptionExpirationChain` now accepts both string-keyed and symbol-keyed hashes, matching `BaseClient#get_option_expiration_chain`
 
 ### Added
 - CLI `sample` command for saving single-expiration option chain snapshots as CSV or JSON

--- a/lib/schwab_rb/data_objects/option_expiration_chain.rb
+++ b/lib/schwab_rb/data_objects/option_expiration_chain.rb
@@ -12,8 +12,8 @@ module SchwabRb
       end
 
       def initialize(data)
-        @expiration_list = data["expirationList"]&.map { |expiration_data| Expiration.new(expiration_data) } || []
-        @status = data["status"]
+        @expiration_list = Array(fetch_value(data, "expirationList")).map { |expiration_data| Expiration.new(expiration_data) }
+        @status = fetch_value(data, "status")
       end
 
       def to_h
@@ -70,17 +70,25 @@ module SchwabRb
 
       include Enumerable
 
+      private
+
+      def fetch_value(data, key)
+        data[key] || data[key.to_sym]
+      end
+
+      public
+
       class Expiration
         attr_reader :expiration_date, :days_to_expiration, :expiration_type,
                     :settlement_type, :option_roots, :standard
 
         def initialize(data)
-          @expiration_date = data["expirationDate"]
-          @days_to_expiration = data["daysToExpiration"]
-          @expiration_type = data["expirationType"]
-          @settlement_type = data["settlementType"]
-          @option_roots = data["optionRoots"]
-          @standard = data["standard"]
+          @expiration_date = fetch_value(data, "expirationDate")
+          @days_to_expiration = fetch_value(data, "daysToExpiration")
+          @expiration_type = fetch_value(data, "expirationType")
+          @settlement_type = fetch_value(data, "settlementType")
+          @option_roots = fetch_value(data, "optionRoots")
+          @standard = fetch_value(data, "standard")
         end
 
         def to_h
@@ -128,6 +136,12 @@ module SchwabRb
 
         def expires_tomorrow?
           @days_to_expiration == 1
+        end
+
+        private
+
+        def fetch_value(data, key)
+          data[key] || data[key.to_sym]
         end
       end
     end

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.9.1"
+  VERSION = "0.9.2"
 end

--- a/spec/data_objects/option_expiration_chain_spec.rb
+++ b/spec/data_objects/option_expiration_chain_spec.rb
@@ -19,6 +19,16 @@ RSpec.describe SchwabRb::DataObjects::OptionExpirationChain do
       expect(expiration_chain.status).to be_nil
     end
 
+    it "accepts symbolized keys from BaseClient JSON parsing" do
+      symbolized_data = JSON.parse(File.read("spec/fixtures/option_expiration_chain.json"), symbolize_names: true)
+
+      chain = described_class.new(symbolized_data)
+
+      expect(chain.expiration_list).not_to be_empty
+      expect(chain.expiration_list.first.expiration_date).to eq("2025-07-21")
+      expect(chain.expiration_list.first.days_to_expiration).to eq(1)
+    end
+
     it "handles missing expiration list gracefully" do
       chain = described_class.new({})
       expect(chain.expiration_list).to eq([])
@@ -193,6 +203,17 @@ RSpec.describe SchwabRb::DataObjects::OptionExpirationChain do
         expect(expiration.settlement_type).to eq("P")
         expect(expiration.option_roots).to eq("SPY")
         expect(expiration.standard).to be(true)
+      end
+
+      it "accepts symbol keys" do
+        symbolized_expiration = described_class.new(expiration_data.transform_keys(&:to_sym))
+
+        expect(symbolized_expiration.expiration_date).to eq("2025-07-21")
+        expect(symbolized_expiration.days_to_expiration).to eq(1)
+        expect(symbolized_expiration.expiration_type).to eq("W")
+        expect(symbolized_expiration.settlement_type).to eq("P")
+        expect(symbolized_expiration.option_roots).to eq("SPY")
+        expect(symbolized_expiration.standard).to be(true)
       end
     end
 


### PR DESCRIPTION
## Summary
- fix `OptionExpirationChain` to read both string and symbol keys
- add regression specs for symbolized input from `BaseClient`
- bump the gem patch version to `0.9.2`
- note the fix in the changelog

## Root Cause
`BaseClient#get_option_expiration_chain` parses API responses with `JSON.parse(..., symbolize_names: true)`, but `OptionExpirationChain` only read string keys. That left fields like `status`, `expirationList`, and nested expiration attributes unset when the data object was built from the client response.

## Validation
- `bundle exec rspec spec/data_objects/option_expiration_chain_spec.rb`
