### PR TITLE
Guard against nil and blank token paths

### DIFF
--- a/lib/schwab_rb/path_support.rb
+++ b/lib/schwab_rb/path_support.rb
@@ -8,6 +8,8 @@ module SchwabRb
     module_function
 
     def expand_path(path)
+      raise ArgumentError, "token_path is nil or empty" if path.nil? || path.to_s.strip.empty?
+
       File.expand_path(path.to_s)
     end
 

--- a/lib/schwab_rb/version.rb
+++ b/lib/schwab_rb/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module SchwabRb
-  VERSION = "0.9.2"
+  VERSION = "0.9.3"
 end

--- a/spec/path_support_spec.rb
+++ b/spec/path_support_spec.rb
@@ -1,0 +1,19 @@
+require "spec_helper"
+
+RSpec.describe SchwabRb::PathSupport do
+  describe ".expand_path" do
+    it "raises for nil input" do
+      expect { described_class.expand_path(nil) }
+        .to raise_error(ArgumentError, "token_path is nil or empty")
+    end
+
+    it "raises for blank string input" do
+      expect { described_class.expand_path("   ") }
+        .to raise_error(ArgumentError, "token_path is nil or empty")
+    end
+
+    it "expands a valid path" do
+      expect(described_class.expand_path("~/token.json")).to eq(File.expand_path("~/token.json"))
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- raise ArgumentError when PathSupport.expand_path receives nil or blank input
- prevent blank token paths from expanding to the current working directory
- add focused specs for nil, blank, and valid path handling

## Testing
- bundle exec rspec spec/path_support_spec.rb